### PR TITLE
Add missing 1.13 api-version and restore legacy list separator

### DIFF
--- a/src/main/java/io/nv/bukkit/CleanroomGenerator/CleanroomChunkGenerator.java
+++ b/src/main/java/io/nv/bukkit/CleanroomGenerator/CleanroomChunkGenerator.java
@@ -35,6 +35,7 @@ public class CleanroomChunkGenerator extends ChunkGenerator {
         }
 
         try {
+            id = id.replace(',', '|');
             if (id.charAt(0) != '.') {
                 // Unless the id starts with a '.' make the first layer bedrock
                 id = "1|minecraft:bedrock|" + id;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 main: io.nv.bukkit.CleanroomGenerator.CleanroomGenerator
 name: ${project.artifactId}
 version: ${project.version}
+api-version: 1.13
 website: ${plugin.website}
 author: ${plugin.author}
 description: ${project.description}


### PR DESCRIPTION
This adds the missing 1.13 api-version in the plugin.yml which fixes that any post 1.13 material names will not work as well as restore the old functionality of splitting with a comma `,` instead of a pipe `|` so that one does not have to edit all generator configs when updating.