### PR TITLE
Added support for new Minecraft minimum height. Closes #28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.nv.bukkit</groupId>
     <artifactId>CleanroomGenerator</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
     <name>Cleanroom Generator</name>
     <description>Custom world generator to generate flat clean rooms. y==0 is bedrock layer=height,block[:datavalue] generator id=layer[|layer[|...]] - Prefix . at the start of the ID to skip bedrock generation at layer0
     </description>
@@ -13,6 +13,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <plugin.author>NVX (Neo_Vortex)</plugin.author>
         <plugin.website>https://dev.bukkit.org/projects/cleanroomgenerator</plugin.website>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/src/main/java/io/nv/bukkit/CleanroomGenerator/CleanroomChunkGenerator.java
+++ b/src/main/java/io/nv/bukkit/CleanroomGenerator/CleanroomChunkGenerator.java
@@ -17,6 +17,8 @@ public class CleanroomChunkGenerator extends ChunkGenerator {
     private Logger log = Logger.getLogger("Minecraft");
     private BlockData[] layerBlock;
     private int[] layerHeight;
+    private boolean noBedrock = false;
+    private boolean newHeight = false;
 
     public CleanroomChunkGenerator() {
         this("");
@@ -35,12 +37,18 @@ public class CleanroomChunkGenerator extends ChunkGenerator {
         }
 
         try {
-            if (id.charAt(0) != '.') {
+            while (id.charAt(0) == '.' || id.charAt(0) == '^'){
+                if (id.charAt(0) == '.'){
+                    noBedrock = true;
+                }
+                if (id.charAt(0) == '^'){
+                    newHeight = true;
+                }
+                id = id.substring(1);
+            }
+            if (!noBedrock) {
                 // Unless the id starts with a '.' make the first layer bedrock
                 id = "1|minecraft:bedrock|" + id;
-            } else {
-                // Else remove the . and don't add the bedrock
-                id = id.substring(1);
             }
 
             String tokens[];
@@ -92,6 +100,9 @@ public class CleanroomChunkGenerator extends ChunkGenerator {
         ChunkData chunk = createChunkData(world);
 
         int y = 0;
+        if (newHeight){
+            y = -64;
+        }
         for (int i = 0; i < layerBlock.length; i++) {
             chunk.setRegion(0, y, 0, 16, y + layerHeight[i], 16, layerBlock[i]);
             y += layerHeight[i];


### PR DESCRIPTION
By adding a '^' to the start of the generation string (before or after the '.' if you want no bedrock), the block layers will start stacking at Y -64.